### PR TITLE
add failing test

### DIFF
--- a/lib/graphql_schema_lexer.mll
+++ b/lib/graphql_schema_lexer.mll
@@ -32,7 +32,7 @@ rule token = parse
   | "on"           { ON }
   | "true"         { BOOL true }
   | "type"         { TYPE }
-  | "input"        { INPUT_TYPE }
+  | "input"        { INPUT }
   | "enum"         { ENUM }
   | "union"        { UNION }
   | "interface"    { INTERFACE }

--- a/lib/graphql_schema_parser.mly
+++ b/lib/graphql_schema_parser.mly
@@ -33,7 +33,7 @@ let rec has_duplicates = function
 %token MUTATION
 %token SUBSCRIPTION
 %token TYPE
-%token INPUT_TYPE
+%token INPUT
 %token ENUM
 %token UNION
 %token INTERFACE
@@ -97,7 +97,7 @@ optional_implementations:
   | optional_implementations IMPLEMENTS name { $3 :: $1 }
 
 input_type_definition:
-  | optional_description INPUT_TYPE name directives field_set
+  | optional_description INPUT name directives field_set
     {
       InputType {
         name = $3;
@@ -132,11 +132,11 @@ enum_definition:
     }
 
 union_definition:
-  | optional_description UNION name directives EQUAL union_vals
+  | optional_description UNION name directives EQUAL PIPE? union_vals
     {
       Union {
         name = $3;
-        possibleVals = $6;
+        possibleVals = $7;
         directives = $4;
         description = $1
       }
@@ -188,9 +188,10 @@ schema_definition:
     }
   }
 
-%inline union_vals:
-  | PIPE? lseparated_list(PIPE, name)
-  { List.map (fun x -> {name = x; description = None}) $2 }
+union_vals:
+  | name  { [ {name = $1; description = None} ] }
+  | name PIPE union_vals
+  { {name = $1; description = None} :: $3 }
 
 enum_vals:
   | LBRACE enum_value_decl+ RBRACE { $2 }
@@ -250,12 +251,19 @@ keyword_name:
   | QUERY { "query" }
   | MUTATION { "mutation" }
   | SUBSCRIPTION { "subscription" }
+  | INPUT { "input" }
+  | INTERFACE { "interface" }
+  | ENUM { "enum" }
+  | UNION { "union" }
+  | SCALAR { "scalar" }
+  | SCHEMA { "schema" }
   (* | FRAGMENT { "fragment" } *)
 
 fragment_name:
   | NULL { "null" }
   | BOOL { string_of_bool $1 }
   | NAME { $1 }
+  | keyword_name { $1 }
 
 name:
   | fragment_name { $1 }

--- a/lib/graphql_sdl.ml
+++ b/lib/graphql_sdl.ml
@@ -58,8 +58,7 @@ let print_position lexbuf =
 let parse_with_error lexbuf =
   try Graphql_schema_parser.doc Graphql_schema_lexer.token lexbuf with
   | Graphql_schema_parser.Error ->
-    Printf.eprintf "%s: syntax error\n" (print_position lexbuf);
-    exit (-1)
+    failwith (Format.sprintf "%s: syntax error\n" (print_position lexbuf))
 
 let parse_and_print lexbuf = parse_with_error lexbuf
 

--- a/test/schema_parser_test.ml
+++ b/test/schema_parser_test.ml
@@ -133,4 +133,14 @@ let tests =
         test_parser_printer_bidirectionality
           "interface Node { id: ID!  }\n\
           \       type Foo implements Node { id: ID! name: String! }" )
+  ; ( "reserved name query as field name"
+    , `Quick
+    , fun () ->
+        test_parser_printer_bidirectionality
+          "type Foo { query: SomeThing! }" )
+  ; ( "reserved name input as argument name"
+    , `Quick
+    , fun () ->
+        test_parser_printer_bidirectionality
+          "type Foo { someThing(input: InputObj!): Query! }" )
   ]

--- a/test/schema_parser_test.ml
+++ b/test/schema_parser_test.ml
@@ -136,8 +136,7 @@ let tests =
   ; ( "reserved name query as field name"
     , `Quick
     , fun () ->
-        test_parser_printer_bidirectionality
-          "type Foo { query: SomeThing! }" )
+        test_parser_printer_bidirectionality "type Foo { query: SomeThing! }" )
   ; ( "reserved name input as argument name"
     , `Quick
     , fun () ->


### PR DESCRIPTION
This adds 2 failing tests for using reserved names (`query` and `input`). However, I think it's likely this issue is for all reserved words.