### PR TITLE
add failing test for default value in input type

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -12,6 +12,15 @@ type argument_definition =
   ; description : string option
   }
 
+type input_field =
+  { typ : Graphql_parser.typ
+  ; name : string
+  ; arguments : argument_definition list
+  ; directives : directive list
+  ; description : string option
+  ; default_value : Graphql_parser.const_value option
+  }
+
 type field =
   { typ : Graphql_parser.typ
   ; name : string
@@ -26,6 +35,13 @@ type schemaTyp =
   ; directives : directive list
   ; description : string option
   ; interfaces : string list option
+  }
+
+type inputTyp =
+  { name : string
+  ; field_defs : input_field list
+  ; directives : directive list
+  ; description : string option
   }
 
 type enumValue =
@@ -58,7 +74,7 @@ type schema_definition =
   }
 
 type optype =
-  | InputType of schemaTyp
+  | InputType of inputTyp
   | Type of schemaTyp
   | Enum of enumTyp
   | Union of enumTyp

--- a/lib/graphql_schema_parser.mly
+++ b/lib/graphql_schema_parser.mly
@@ -97,14 +97,13 @@ optional_implementations:
   | optional_implementations IMPLEMENTS name { $3 :: $1 }
 
 input_type_definition:
-  | optional_description INPUT name directives field_set
+  | optional_description INPUT name directives input_field_set
     {
       InputType {
         name = $3;
         field_defs = $5;
         directives = $4;
         description = $1;
-        interfaces = None
       }
     }
 
@@ -196,8 +195,14 @@ union_vals:
 enum_vals:
   | LBRACE enum_value_decl+ RBRACE { $2 }
 
+mk_field_set(X):
+  | LBRACE X+ RBRACE { $2 }
+
 field_set:
-  | LBRACE field+ RBRACE { $2 }
+  mk_field_set(field) { $1 }
+
+input_field_set:
+  mk_field_set(input_field) { $1 }
 
 field:
   optional_description name default_list(arguments) COLON typ directives
@@ -208,6 +213,19 @@ field:
         arguments = $3;
         directives = $6;
         description = $1;
+      }
+    }
+
+input_field:
+  optional_description name default_list(arguments) COLON typ default_value? directives
+    {
+       {
+        name = $2;
+        typ = $5;
+        arguments = $3;
+        directives = $7;
+        description = $1;
+        default_value = $6
       }
     }
 

--- a/test/schema_parser_test.ml
+++ b/test/schema_parser_test.ml
@@ -142,4 +142,9 @@ let tests =
     , fun () ->
         test_parser_printer_bidirectionality
           "type Foo { someThing(input: InputObj!): Query! }" )
+  ; ( "default value in input type"
+    , `Quick
+    , fun () ->
+        test_parser_printer_bidirectionality
+          "input SomeInput { something: SortOrder = ASC }" )
   ]


### PR DESCRIPTION
This adds a failing test for having a default value on the field of an input type. Found by trying to parse the OneGraph schema.