### PR TITLE
add failing test for directive definition

### DIFF
--- a/test/schema_parser_test.ml
+++ b/test/schema_parser_test.ml
@@ -142,4 +142,9 @@ let tests =
     , fun () ->
         test_parser_printer_bidirectionality
           "type Foo { someThing(input: InputObj!): Query! }" )
+  ; ( "directive definitions"
+    , `Quick
+    , fun () ->
+        test_parser_printer_bidirectionality
+          "directive @deprecated(reason: String = \"No longer supported\", anotherArg: Boolean) on FIELD_DEFINITION | ENUM_VALUE" )
   ]


### PR DESCRIPTION
Here's a failing test for directive definitions. And [here's](https://spec.graphql.org/June2018/#sec-Type-System.Directives) the relevant spec entry.